### PR TITLE
Be more relaxed on disk requirement

### DIFF
--- a/steward_tech_check.py
+++ b/steward_tech_check.py
@@ -100,7 +100,7 @@ rules = {
                 "memory": ">= 8589934592",
                 "disk": {
                     'path': "/home/indy",
-                    'size': ">= 1099511627776",
+                    'size': ">= 1000000000000",
                     'raid': True
                 },
                 'hardware': 'attested',


### PR DESCRIPTION
On my machine I have a 1TB disk but some bytes are lost due to management.
I suggest that the script checks for 'about one TB'.