### PR TITLE
Update package versions for indy-node 1.8.3

### DIFF
--- a/installer/network_pkg_versions
+++ b/installer/network_pkg_versions
@@ -1,15 +1,23 @@
-testnet:
-  indy-node: "1.6.82"
-  sovrin: "1.1.34"
-  libindy: "1.7.0"
-  libnullpay: "1.7.0"
-  libvcx: "0.1.27328536-fb7b7b6"
-  indy-cli: "1.7.0"
+buildernet:
+  indy-node: "1.6.83"
+  sovrin: "1.1.35"
+  libindy: "1.8.1"
+  libnullpay: "1.8.1"
+  libvcx: "0.2.34516997-f3254f8"
+  indy-cli: "1.8.1"
+
+stagingnet:
+  indy-node: "1.6.83"
+  sovrin: "1.1.35"
+  libindy: "1.8.1"
+  libnullpay: "1.8.1"
+  libvcx: "0.2.34516997-f3254f8"
+  indy-cli: "1.8.1"
 
 mainnet:
-  indy-node: "1.6.82"
+  indy-node: "1.6.83"
   sovrin: "1.1.6"
-  libindy: "1.7.0"
-  libnullpay: "1.7.0"
-  libvcx: "0.1.27328536-fb7b7b6"
-  indy-cli: "1.7.0"
+  libindy: "1.8.1"
+  libnullpay: "1.8.1"
+  libvcx: "0.2.34516997-f3254f8"
+  indy-cli: "1.8.1"

--- a/installer/network_pkg_versions
+++ b/installer/network_pkg_versions
@@ -5,6 +5,9 @@ buildernet:
   libnullpay: "1.8.1"
   libvcx: "0.2.34516997-f3254f8"
   indy-cli: "1.8.1"
+  libsovtoken: "0.9.6"
+  sovtoken: "0.9.9"
+  sovtokenfees: "0.9.9"
 
 stagingnet:
   indy-node: "1.6.83"
@@ -13,6 +16,9 @@ stagingnet:
   libnullpay: "1.8.1"
   libvcx: "0.2.34516997-f3254f8"
   indy-cli: "1.8.1"
+  libsovtoken: "0.9.6"
+  sovtoken: "0.9.9"
+  sovtokenfees: "0.9.9"
 
 mainnet:
   indy-node: "1.6.83"
@@ -21,3 +27,6 @@ mainnet:
   libnullpay: "1.8.1"
   libvcx: "0.2.34516997-f3254f8"
   indy-cli: "1.8.1"
+  libsovtoken: "None"
+  sovtoken: "None"
+  sovtokenfees: "None"


### PR DESCRIPTION
All networks are currently on this version. The only current
difference is that mainnet does not have libsovtoken, and thus
cannot have a current sovrin package.

Signed-off-by: Mike Bailey <mike.bailey@evernym.com>