### PR TITLE
Adjust time sync test for container environments

### DIFF
--- a/steward_tech_check.py
+++ b/steward_tech_check.py
@@ -1140,24 +1140,28 @@ class RuleValidator:
             'details': [],
             'comment': 'None'
         }
-        cur_procs = self.node.running_procs()
-        failed = False
-        for processes in criteria['processes']:
-            fp = False
-            for cp in cur_procs:
-                if isinstance(processes, str):
-                    processes = [processes]
-                if cp['cmd'].split()[0] in processes:
-                    fp = True
-                    res['details'].append('Found required proc: {} at pid: {}'.format(cp['cmd'],cp['pid']))
-                    break
-            if not fp:
-                failed = True
-                res['result'] = bcolors.FAIL + 'FAILED' + bcolors.ENDC
-                res['action_needed'].append("Start required process: {}".format(', '.join(processes)))
-                res['details'].append("Can't find required process: {}".format(', '.join(processes)))
-        if not failed:
-            res['result'] = bcolors.OKGREEN + "PASSED" + bcolors.ENDC
+        if self.node.mach_type == 'container':
+            res['action_needed'].append("Verify that the host system has proper time synchronisation")
+            res['details'].append("Containers use the clock of their host")
+        else:
+            cur_procs = self.node.running_procs()
+            failed = False
+            for processes in criteria['processes']:
+                fp = False
+                for cp in cur_procs:
+                    if isinstance(processes, str):
+                        processes = [processes]
+                    if cp['cmd'].split()[0] in processes:
+                        fp = True
+                        res['details'].append('Found required proc: {} at pid: {}'.format(cp['cmd'],cp['pid']))
+                        break
+                if not fp:
+                    failed = True
+                    res['result'] = bcolors.FAIL + 'FAILED' + bcolors.ENDC
+                    res['action_needed'].append("Start required process: {}".format(', '.join(processes)))
+                    res['details'].append("Can't find required process: {}".format(', '.join(processes)))
+            if not failed:
+                res['result'] = bcolors.OKGREEN + "PASSED" + bcolors.ENDC
         return res
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adjusts the `steward_tech_check.py` script to not fail on missing ntpd / systemd-timesyncd processes for container environments. They are using the same clock as the host system and should rely on the host to do the syncing.

Instead the result will be set to UNKNOWN and appropiate informations about the situation will be given.

Fixes #39 