### PR TITLE
handle %lo, %eth, etc. in ss output

### DIFF
--- a/steward_tech_check.py
+++ b/steward_tech_check.py
@@ -534,7 +534,7 @@ class Node:
                                 proto = proto.rstrip('6')
                             local = False
                             lface = lsplit[3].split(':')
-                            iface = ':'.join(lface[:-1])
+                            iface = ':'.join(lface[:-1]).split('%')[0]
                             port = lface[-1]
                             if lsplit[5] in [ 'LISTEN', 'UNCONN']:
                                 prog_pid = ' '.join(lsplit[6:]).split('/')


### PR DESCRIPTION
/bin/ss -tulp outputs some local addresses in the form 127.0.0.53%lo:domain